### PR TITLE
feat: Optionally constrain the screenshot size

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,9 +4,9 @@ import { ios } from './lib/ios.js';
 const IOS = Symbol('ios');
 const UNKNOWN = Symbol('unknown');
 
-export default function screenshot(view: ObjC.Object): Promise<ArrayBuffer> {
+export default function screenshot(view: ObjC.Object, options?: ScreenshotOptions): Promise<ArrayBuffer> {
   if (getOS() === IOS) {
-    return ios(view);
+    return ios(view, options);
   } else {
     return new Promise(function (_, reject) {
       reject(new Error('Not yet implemented for this OS'));
@@ -28,4 +28,8 @@ function detectOS(): symbol {
   } else {
     return UNKNOWN;
   }
+}
+
+export interface ScreenshotOptions {
+  constrainSize?: number;
 }

--- a/lib/ios.ts
+++ b/lib/ios.ts
@@ -19,15 +19,16 @@ export function ios(view: ObjC.Object, options: ScreenshotOptions | undefined): 
 
     const format = api.UIGraphicsImageRendererFormat.preferredFormat();
 
-    if (options?.constrainSize !== undefined) {
-      if (typeof options.constrainSize !== "number" || options.constrainSize <= 0) {
+    const constrainSize = options?.constrainSize;
+    if (constrainSize !== undefined) {
+      if (typeof constrainSize !== "number" || constrainSize <= 0) {
         throw new Error("Invalid constrainSize value");
       }
 
       const maxDimension = Math.max(size[0], size[1]);
       const scale: number = format.scale().valueOf();
-      if (maxDimension * scale > options.constrainSize) {
-        format.setScale_(options.constrainSize / maxDimension);
+      if (maxDimension * scale > constrainSize) {
+        format.setScale_(constrainSize / maxDimension);
       }
     }
 


### PR DESCRIPTION
Add a second optional argument, of type `ScreenshotOptions`.

Implement the `constrainSize` option which, given a value in pixels, scales the rendering context to ensure the maximum dimension of the final image will to be at most the given value.

In this way memory is never wasted, because the image is rendered already of the requested size, preventing the user from having to scale it after the fact.

Bonus: use non-deprecated APIs.